### PR TITLE
Refactored coord from `(u8, u8)` to `(u8, u16)`

### DIFF
--- a/src/chording.rs
+++ b/src/chording.rs
@@ -15,7 +15,7 @@
 use crate::layout::Event;
 use heapless::Vec;
 
-type KeyPosition = (u8, u8);
+type KeyPosition = (u8, u16);
 
 /// Description of the virtual key corresponding to a given chord.
 /// keys are the coordinates of the multiple keys that make up the chord

--- a/src/debounce.rs
+++ b/src/debounce.rs
@@ -69,7 +69,7 @@ impl<T: PartialEq> Debouncer<T> {
     ///
     /// `T` must be some kind of array of array of bool.
     ///
-    /// Panics if the coordinates doesn't fit in a `(u8, u8)`.
+    /// Panics if the coordinates doesn't fit in a `(u8, u16)`.
     ///
     /// # Example
     ///
@@ -110,8 +110,8 @@ impl<T: PartialEq> Debouncer<T> {
                     .flat_map(move |(i, (o, n))| {
                         o.into_iter().zip(n.into_iter()).enumerate().filter_map(
                             move |(j, bools)| match bools {
-                                (false, true) => Some(Event::Press(i as u8, j as u8)),
-                                (true, false) => Some(Event::Release(i as u8, j as u8)),
+                                (false, true) => Some(Event::Press(i as u8, j as u16)),
+                                (true, false) => Some(Event::Release(i as u8, j as u16)),
                                 _ => None,
                             },
                         )

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -59,9 +59,9 @@ where
     {
         let mut keys = [[false; CS]; RS];
 
-        for (ri, row) in (&mut self.rows).iter_mut().enumerate() {
+        for (ri, row) in self.rows.iter_mut().enumerate() {
             row.set_low()?;
-            for (ci, col) in (&self.cols).iter().enumerate() {
+            for (ci, col) in self.cols.iter().enumerate() {
                 if col.is_low()? {
                     keys[ri][ci] = true;
                 }
@@ -106,7 +106,7 @@ where
     {
         let mut keys = [[false; CS]; RS];
 
-        for (ri, row) in (&mut self.pins).iter_mut().enumerate() {
+        for (ri, row) in self.pins.iter_mut().enumerate() {
             for (ci, col_option) in row.iter().enumerate() {
                 if let Some(col) = col_option {
                     if col.is_low()? {


### PR DESCRIPTION
As discussed in https://github.com/jtroo/kanata/issues/108

This PR extends the `coord`s to support bigger `y` indices.
It enables more events like mouse button presses etc. (Or in other words *all* possible values of `Kanata::keys::OsCode`).
The change is *breaking* so I guess it needs a new "major" release.
